### PR TITLE
Reproduction

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v1.2.0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+This shouldn't show any check issues.

--- a/test
+++ b/test
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-if make -s foobar > /dev/null 2>/dev/null
+set -efu -o pipefail
+
+if make -s foobar 2>/dev/null
 then
   echo "shouldn't have succeeded"
   exit 1

--- a/test
+++ b/test
@@ -6,5 +6,3 @@ then
   echo "shouldn't have succeeded"
   exit 1
 fi
-
-exit 0

--- a/test
+++ b/test
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-set -efu -o pipefail
 
-if make -s foobar 2>/dev/null
+if make -s foobar > /dev/null 2>/dev/null
 then
   echo "shouldn't have succeeded"
   exit 1


### PR DESCRIPTION
If you look at the check output, you'll see `Makefile:3: recipe for target 'foobar' failed` which _shouldn't_ show up, if you look at the code (it should go to `/dev/null`)

In a different (private) repo, we're seeing this output as `##[error]Makefile:59: recipe for target 'foobar' failed` and red text, which is picked up as a check failure - it doesn't fail the build, but does show up in the files changed view as an error (on the wrong file, which is a separate issue)